### PR TITLE
Avoid eternal loop

### DIFF
--- a/runtime/app.py
+++ b/runtime/app.py
@@ -69,6 +69,8 @@ def process_later(event: CloudWatchEvent):
             if message:
                 process_now(message)
                 # update the db here?
+            else:
+                break
 
 
 @app.on_sqs_message(queue='do-now', batch_size=1)


### PR DESCRIPTION
The process_later function had no break clause, which meant it would run until the Lambda stopped running. This should fix that issue